### PR TITLE
Adding error case for UnknownTopicOrPartition into Read loop 

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1661,7 +1661,7 @@ func (r *reader) run(ctx context.Context, offset int64) {
 				conn.Close()
 
 				// The next call to .initialize will re-establish a connection to the proper
-				// partition leader.
+				// topic/partition broker combo.
 				r.stats.rebalances.observe(1)
 				break readLoop
 			case NotLeaderForPartition:


### PR DESCRIPTION
Adding error case for UnknownTopicOrPartition into Read loop 
This error can happen when a partition is moved brokers, and can be recovered from. It should be treated similar as a Leadership move which is handled in the case below