### PR TITLE
Nr/add max bytes

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -184,7 +184,7 @@ func (batch *Batch) readMessage(
 		batch.offset = offset + 1
 	case errShortRead:
 		// As an "optimization" kafka truncates the returned response after
-		// producing MaxBytes, which could then cause the code to return
+		// producing MaxMessageBytes, which could then cause the code to return
 		// errShortRead.
 		err = batch.msgs.discard()
 		switch {

--- a/conn.go
+++ b/conn.go
@@ -123,7 +123,7 @@ func NewConnWith(conn net.Conn, config ConnConfig) *Conn {
 		requiredAcks: -1,
 	}
 
-	// The fetch request needs to ask for a MaxBytes value that is at least
+	// The fetch request needs to ask for a MaxMessageBytes value that is at least
 	// enough to load the control data of the response. To avoid having to
 	// recompute it on every read, it is cached here in the Conn value.
 	c.fetchMinSize = (fetchResponseV2{

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -50,7 +50,6 @@ func testDialerLookupPartitions(t *testing.T, ctx context.Context, d *Dialer) {
 	w.Close()
 
 	partitions, err := d.LookupPartitions(ctx, "tcp", "localhost:9092", topic)
-
 	if err != nil {
 		t.Error(err)
 		return

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -41,7 +41,7 @@ func TestProtocol(t *testing.T) {
 		metadataResponseV1{
 			Brokers: []brokerMetadataV1{
 				{NodeID: 1, Host: "localhost", Port: 9001},
-				{NodeID: 2, Host: "localhost", Port: 9002, Rack:"rack2"},
+				{NodeID: 2, Host: "localhost", Port: 9002, Rack: "rack2"},
 			},
 			ControllerID: 2,
 			Topics: []topicMetadataV1{

--- a/writer.go
+++ b/writer.go
@@ -78,7 +78,7 @@ type WriterConfig struct {
 	// a partition.
 	//
 	// The default is to use a kafka default value of 1048576.
-	MaxBytes int
+	MaxMessageBytes int
 
 	// Time limit on how often incomplete message batches will be flushed to
 	// kafka.
@@ -139,11 +139,12 @@ type WriterStats struct {
 	Rebalances int64 `metric:"kafka.writer.rebalance.count" type:"counter"`
 	Errors     int64 `metric:"kafka.writer.error.count"     type:"counter"`
 
-	DialTime  DurationStats `metric:"kafka.writer.dial.seconds"`
-	WriteTime DurationStats `metric:"kafka.writer.write.seconds"`
-	WaitTime  DurationStats `metric:"kafka.writer.wait.seconds"`
-	Retries   SummaryStats  `metric:"kafka.writer.retries.count"`
-	BatchSize SummaryStats  `metric:"kafka.writer.batch.size"`
+	DialTime       DurationStats `metric:"kafka.writer.dial.seconds"`
+	WriteTime      DurationStats `metric:"kafka.writer.write.seconds"`
+	WaitTime       DurationStats `metric:"kafka.writer.wait.seconds"`
+	Retries        SummaryStats  `metric:"kafka.writer.retries.count"`
+	BatchSize      SummaryStats  `metric:"kafka.writer.batch.size"`
+	BatchSizeBytes SummaryStats  `metric:"kafka.writer.batch.size.bytes"`
 
 	MaxAttempts       int64         `metric:"kafka.writer.attempts.max"       type:"gauge"`
 	MaxBatchSize      int64         `metric:"kafka.writer.batch.max"          type:"gauge"`
@@ -166,17 +167,18 @@ type WriterStats struct {
 // This is easily accomplished by always allocating this struct directly, (i.e. using a pointer to the struct).
 // See https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 type writerStats struct {
-	dials      counter
-	writes     counter
-	messages   counter
-	bytes      counter
-	rebalances counter
-	errors     counter
-	dialTime   summary
-	writeTime  summary
-	waitTime   summary
-	retries    summary
-	batchSize  summary
+	dials          counter
+	writes         counter
+	messages       counter
+	bytes          counter
+	rebalances     counter
+	errors         counter
+	dialTime       summary
+	writeTime      summary
+	waitTime       summary
+	retries        summary
+	batchSize      summary
+	batchSizeBytes summary
 }
 
 // NewWriter creates and returns a new Writer configured with config.
@@ -215,8 +217,9 @@ func NewWriter(config WriterConfig) *Writer {
 		config.BatchSize = 100
 	}
 
-	if config.MaxBytes == 0 {
-		config.MaxBytes = 1048576
+	if config.MaxMessageBytes == 0 {
+		// 1048576 == 1MB which is the Kafka default.
+		config.MaxMessageBytes = 1048576
 	}
 
 	if config.BatchTimeout == 0 {
@@ -286,10 +289,10 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 		}
 
 		for _, msg := range msgs {
-			if int(msg.message().size()) > w.config.MaxBytes {
+			if int(msg.message().size()) > w.config.MaxMessageBytes {
 				err := errors.New(fmt.Sprintf("The message is %d bytes "+
 					"when serialized which is larger than the maximum request size you "+
-					"have configured with the %v configuration.", msg.message().size(), w.config.MaxBytes))
+					"have configured with the %v configuration.", msg.message().size(), w.config.MaxMessageBytes))
 				w.mutex.RUnlock()
 				return err
 			}
@@ -378,6 +381,7 @@ func (w *Writer) Stats() WriterStats {
 		WaitTime:          w.stats.waitTime.snapshotDuration(),
 		Retries:           w.stats.retries.snapshot(),
 		BatchSize:         w.stats.batchSize.snapshot(),
+		BatchSizeBytes:    w.stats.batchSizeBytes.snapshot(),
 		MaxAttempts:       int64(w.config.MaxAttempts),
 		MaxBatchSize:      int64(w.config.BatchSize),
 		BatchTimeout:      w.config.BatchTimeout,
@@ -523,39 +527,39 @@ type partitionWriter interface {
 }
 
 type writer struct {
-	brokers      []string
-	topic        string
-	partition    int
-	requiredAcks int
-	batchSize    int
-	maxBytes     int
-	batchTimeout time.Duration
-	writeTimeout time.Duration
-	dialer       *Dialer
-	msgs         chan writerMessage
-	join         sync.WaitGroup
-	stats        *writerStats
-	codec        CompressionCodec
-	logger       *log.Logger
-	errorLogger  *log.Logger
+	brokers         []string
+	topic           string
+	partition       int
+	requiredAcks    int
+	batchSize       int
+	maxMessageBytes int
+	batchTimeout    time.Duration
+	writeTimeout    time.Duration
+	dialer          *Dialer
+	msgs            chan writerMessage
+	join            sync.WaitGroup
+	stats           *writerStats
+	codec           CompressionCodec
+	logger          *log.Logger
+	errorLogger     *log.Logger
 }
 
 func newWriter(partition int, config WriterConfig, stats *writerStats) *writer {
 	w := &writer{
-		brokers:      config.Brokers,
-		topic:        config.Topic,
-		partition:    partition,
-		requiredAcks: config.RequiredAcks,
-		batchSize:    config.BatchSize,
-		maxBytes:     config.MaxBytes,
-		batchTimeout: config.BatchTimeout,
-		writeTimeout: config.WriteTimeout,
-		dialer:       config.Dialer,
-		msgs:         make(chan writerMessage, config.QueueCapacity),
-		stats:        stats,
-		codec:        config.CompressionCodec,
-		logger:       config.Logger,
-		errorLogger:  config.ErrorLogger,
+		brokers:         config.Brokers,
+		topic:           config.Topic,
+		partition:       partition,
+		requiredAcks:    config.RequiredAcks,
+		batchSize:       config.BatchSize,
+		maxMessageBytes: config.MaxMessageBytes,
+		batchTimeout:    config.BatchTimeout,
+		writeTimeout:    config.WriteTimeout,
+		dialer:          config.Dialer,
+		msgs:            make(chan writerMessage, config.QueueCapacity),
+		stats:           stats,
+		codec:           config.CompressionCodec,
+		logger:          config.Logger,
+		errorLogger:     config.ErrorLogger,
 	}
 	w.join.Add(1)
 	go w.run()
@@ -597,7 +601,7 @@ func (w *writer) run() {
 	var resch = make([](chan<- error), 0, w.batchSize)
 	var lstMsg *writerMessage
 	var lastFlushAt = time.Now()
-	var currLength int
+	var batchSizeBytes int
 
 	defer func() {
 		if conn != nil {
@@ -607,9 +611,12 @@ func (w *writer) run() {
 
 	for !done {
 		var mustFlush bool
+		// lstMsg gets set when the next message would put the maxMessageBytes  over the limit.
+		// If a lstMsg exists we need to add it to the batch so we don't lose it.
 		if lstMsg != nil {
 			batch = append(batch, lstMsg.msg)
 			resch = append(resch, lstMsg.res)
+			batchSizeBytes += int(lstMsg.msg.message().size())
 			lstMsg = nil
 		}
 		select {
@@ -617,8 +624,8 @@ func (w *writer) run() {
 			if !ok {
 				done, mustFlush = true, true
 			} else {
-				if int(wm.msg.message().size())+currLength > w.maxBytes {
-					// If the size of the current message puts us over the limit,
+				if int(wm.msg.message().size())+batchSizeBytes > w.maxMessageBytes {
+					// If the size of the current message puts us over the maxMessageBytes limit,
 					// store the message but don't send it in this batch.
 					mustFlush = true
 					lstMsg = &wm
@@ -626,8 +633,8 @@ func (w *writer) run() {
 				}
 				batch = append(batch, wm.msg)
 				resch = append(resch, wm.res)
-				currLength += int(wm.msg.message().size())
-				mustFlush = len(batch) >= w.batchSize || currLength == w.maxBytes
+				batchSizeBytes += int(wm.msg.message().size())
+				mustFlush = len(batch) >= w.batchSize || batchSizeBytes >= w.maxMessageBytes
 			}
 
 		case now := <-ticker.C:
@@ -636,6 +643,7 @@ func (w *writer) run() {
 
 		if mustFlush {
 			lastFlushAt = time.Now()
+			w.stats.batchSizeBytes.observe(int64(batchSizeBytes))
 
 			if len(batch) == 0 {
 				continue
@@ -659,7 +667,7 @@ func (w *writer) run() {
 
 			batch = batch[:0]
 			resch = resch[:0]
-			currLength = 0
+			batchSizeBytes = 0
 		}
 	}
 }

--- a/writer.go
+++ b/writer.go
@@ -272,7 +272,6 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 		return nil
 	}
 
-
 	var res = make(chan error, len(msgs))
 	var err error
 
@@ -288,9 +287,9 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 
 		for _, msg := range msgs {
 			if int(msg.message().size()) > w.config.MaxBytes {
-				err := errors.New(fmt.Sprintf("The message is %d bytes " +
-					"when serialized which is larger than the maximum request size you " +
-					"have configured with the %v configuration.",msg.message().size(), w.config.MaxBytes))
+				err := errors.New(fmt.Sprintf("The message is %d bytes "+
+					"when serialized which is larger than the maximum request size you "+
+					"have configured with the %v configuration.", msg.message().size(), w.config.MaxBytes))
 				w.mutex.RUnlock()
 				return err
 			}

--- a/writer_test.go
+++ b/writer_test.go
@@ -169,8 +169,8 @@ func testWriterMaxBytes(t *testing.T) {
 
 	createTopic(t, topic, 1)
 	w := newTestWriter(WriterConfig{
-		Topic:    topic,
-		MaxBytes: 25,
+		Topic:           topic,
+		MaxMessageBytes: 25,
 	})
 	defer w.Close()
 
@@ -244,10 +244,10 @@ func testWrtierBatchBytes(t *testing.T) {
 	}
 
 	w := newTestWriter(WriterConfig{
-		Topic:        topic,
-		MaxBytes:     48,
-		BatchTimeout: math.MaxInt32 * time.Second,
-		Balancer:     &RoundRobin{},
+		Topic:           topic,
+		MaxMessageBytes: 48,
+		BatchTimeout:    math.MaxInt32 * time.Second,
+		Balancer:        &RoundRobin{},
 	})
 	defer w.Close()
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,18 @@ func TestWriter(t *testing.T) {
 		{
 			scenario: "running out of max attempts should return an error",
 			function: testWriterMaxAttemptsErr,
+		},
+		{
+			scenario: "writing a message larger then the max bytes should return an error",
+			function: testWriterMaxBytes,
+		},
+		{
+			scenario: "writing a batch of message based on batch byte size",
+			function: testWrtierBatchBytes,
+		},
+		{
+			scenario: "writing a batch of messages",
+			function: testWrtierBatchSize,
 		},
 	}
 
@@ -151,6 +164,37 @@ func testWriterMaxAttemptsErr(t *testing.T) {
 	}
 }
 
+func testWriterMaxBytes(t *testing.T) {
+	const topic = "test-writer-2"
+
+	createTopic(t, topic, 1)
+	w := newTestWriter(WriterConfig{
+		Topic:    topic,
+		MaxBytes: 25,
+	})
+	defer w.Close()
+
+	if err := w.WriteMessages(context.Background(), Message{
+		Value: []byte("Hi"),
+	}); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := w.WriteMessages(context.Background(), Message{
+		Value: []byte("Hello World!"),
+	}); err == nil {
+		t.Error("expected error")
+		return
+	} else if err != nil {
+		if !strings.Contains(err.Error(), "larger than the maximum request") {
+			t.Errorf("unexpected error: %s", err)
+			return
+		}
+	}
+
+}
+
 func readOffset(topic string, partition int) (offset int64, err error) {
 	var conn *Conn
 
@@ -187,5 +231,103 @@ func readPartition(topic string, partition int, offset int64) (msgs []Message, e
 		}
 
 		msgs = append(msgs, msg)
+	}
+}
+
+func testWrtierBatchBytes(t *testing.T) {
+	const topic = "test-writer-1-bytes"
+
+	createTopic(t, topic, 1)
+	offset, err := readOffset(topic, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := newTestWriter(WriterConfig{
+		Topic:        topic,
+		MaxBytes:     48,
+		BatchTimeout: math.MaxInt32 * time.Second,
+		Balancer:     &RoundRobin{},
+	})
+	defer w.Close()
+
+	if err := w.WriteMessages(context.Background(), []Message{
+		Message{Value: []byte("Hi")}, // 24 Bytes
+		Message{Value: []byte("By")}, // 24 Bytes
+	}...); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if w.Stats().Writes > 1 {
+		t.Error("didn't batch messages")
+		return
+	}
+	msgs, err := readPartition(topic, 0, offset)
+
+	if err != nil {
+		t.Error("error reading partition", err)
+		return
+	}
+
+	if len(msgs) != 2 {
+		t.Error("bad messages in partition", msgs)
+		return
+	}
+
+	for _, m := range msgs {
+		if string(m.Value) == "Hi" || string(m.Value) == "By" {
+			continue
+		}
+		t.Error("bad messages in partition", msgs)
+	}
+}
+
+func testWrtierBatchSize(t *testing.T) {
+	const topic = "test-writer-1-batch"
+
+	createTopic(t, topic, 1)
+	offset, err := readOffset(topic, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := newTestWriter(WriterConfig{
+		Topic:        topic,
+		BatchSize:    2,
+		BatchTimeout: math.MaxInt32 * time.Second,
+		Balancer:     &RoundRobin{},
+	})
+	defer w.Close()
+
+	if err := w.WriteMessages(context.Background(), []Message{
+		Message{Value: []byte("Hi")}, // 24 Bytes
+		Message{Value: []byte("By")}, // 24 Bytes
+	}...); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if w.Stats().Writes > 1 {
+		t.Error("didn't batch messages")
+		return
+	}
+	msgs, err := readPartition(topic, 0, offset)
+
+	if err != nil {
+		t.Error("error reading partition", err)
+		return
+	}
+
+	if len(msgs) != 2 {
+		t.Error("bad messages in partition", msgs)
+		return
+	}
+
+	for _, m := range msgs {
+		if string(m.Value) == "Hi" || string(m.Value) == "By" {
+			continue
+		}
+		t.Error("bad messages in partition", msgs)
 	}
 }


### PR DESCRIPTION
This is on-top of https://github.com/newrelic-forks/kafka-go/pull/3 

This is adding a option to the producer to send in batches of a max bytes size instead of just message size. It plays much nicer with kafka as you want to limit the size of a message based on topic config and consumer config. 