### PR TITLE
Bug fixes with kafka-go retry logic 

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -685,7 +685,6 @@ func (c *Conn) ReadBatch(minBytes, maxBytes int) *Batch {
 // ReadBatchWith in every way is similar to ReadBatch. ReadBatch is configured
 // with the default values in ReadBatchConfig except for minBytes and maxBytes.
 func (c *Conn) ReadBatchWith(cfg ReadBatchConfig) *Batch {
-
 	var adjustedDeadline time.Time
 	var maxFetch = int(c.fetchMaxBytes)
 

--- a/dialer.go
+++ b/dialer.go
@@ -185,6 +185,7 @@ func (d *Dialer) LookupPartition(ctx context.Context, network string, address st
 	case <-ctx.Done():
 		err = ctx.Err()
 	}
+
 	return prt, err
 }
 
@@ -248,7 +249,6 @@ func (d *Dialer) connect(ctx context.Context, network, address string, connCfg C
 	if err != nil {
 		return nil, err
 	}
-
 	conn := NewConnWith(c, connCfg)
 
 	if d.SASLMechanism != nil {

--- a/error.go
+++ b/error.go
@@ -107,15 +107,12 @@ func (e Error) Temporary() bool {
 	return e == InvalidMessage ||
 		e == UnknownTopicOrPartition ||
 		e == LeaderNotAvailable ||
-		e == NotLeaderForPartition ||
 		e == RequestTimedOut ||
 		e == NetworkException ||
 		e == GroupLoadInProgress ||
 		e == GroupCoordinatorNotAvailable ||
-		e == NotCoordinatorForGroup ||
 		e == NotEnoughReplicas ||
 		e == NotEnoughReplicasAfterAppend ||
-		e == NotController ||
 		e == KafkaStorageError ||
 		e == FetchSessionIDNotFound ||
 		e == InvalidFetchSessionEpoch ||

--- a/error.go
+++ b/error.go
@@ -102,19 +102,8 @@ func (e Error) Timeout() bool {
 
 // Temporary returns true if the operation that generated the error may succeed
 // if retried at a later time.
+// See https://kafka.apache.org/protocol#protocol_error_codes
 func (e Error) Temporary() bool {
-	return e == LeaderNotAvailable ||
-		e == BrokerNotAvailable ||
-		e == ReplicaNotAvailable ||
-		e == GroupLoadInProgress ||
-		e == GroupCoordinatorNotAvailable ||
-		e == RebalanceInProgress ||
-		e.Timeout()
-}
-
-// Retriable returns true if the error is one the "RETRIABLE" error codes from:
-// https://kafka.apache.org/protocol#protocol_error_codes
-func (e Error) Retriable() bool {
 	return e == InvalidMessage ||
 		e == UnknownTopicOrPartition ||
 		e == LeaderNotAvailable ||
@@ -474,12 +463,6 @@ func isTemporary(err error) bool {
 		Temporary() bool
 	})
 	return ok && e.Temporary()
-}
-func isRetriable(err error) bool {
-	e, ok := err.(interface {
-		Retriable() bool
-	})
-	return ok && e.Retriable()
 }
 func silentEOF(err error) error {
 	if err == io.EOF {

--- a/error.go
+++ b/error.go
@@ -22,6 +22,7 @@ const (
 	MessageSizeTooLarge                Error = 10
 	StaleControllerEpoch               Error = 11
 	OffsetMetadataTooLarge             Error = 12
+	NetworkException                   Error = 13
 	GroupLoadInProgress                Error = 14
 	GroupCoordinatorNotAvailable       Error = 15
 	NotCoordinatorForGroup             Error = 16
@@ -85,6 +86,8 @@ const (
 	FencedLeaderEpoch                  Error = 74
 	UnknownLeaderEpoch                 Error = 75
 	UnsupportedCompressionType         Error = 76
+	OffsetNotAvailable                 Error = 78
+	PreferredLeaderNotAvailable        Error = 80
 )
 
 // Error satisfies the error interface.
@@ -106,6 +109,32 @@ func (e Error) Temporary() bool {
 		e == GroupLoadInProgress ||
 		e == GroupCoordinatorNotAvailable ||
 		e == RebalanceInProgress ||
+		e.Timeout()
+}
+
+// Retriable returns true if the error is one the "RETRIABLE" error codes from:
+// https://kafka.apache.org/protocol#protocol_error_codes
+func (e Error) Retriable() bool {
+	return e == InvalidMessage ||
+		e == UnknownTopicOrPartition ||
+		e == LeaderNotAvailable ||
+		e == NotLeaderForPartition ||
+		e == RequestTimedOut ||
+		e == NetworkException ||
+		e == GroupLoadInProgress ||
+		e == GroupCoordinatorNotAvailable ||
+		e == NotCoordinatorForGroup ||
+		e == NotEnoughReplicas ||
+		e == NotEnoughReplicasAfterAppend ||
+		e == NotController ||
+		e == KafkaStorageError ||
+		e == FetchSessionIDNotFound ||
+		e == InvalidFetchSessionEpoch ||
+		e == ListenerNotFound ||
+		e == FencedLeaderEpoch ||
+		e == UnknownLeaderEpoch ||
+		e == OffsetNotAvailable ||
+		e == PreferredLeaderNotAvailable ||
 		e.Timeout()
 }
 
@@ -138,6 +167,8 @@ func (e Error) Title() string {
 		return "Stale Controller Epoch"
 	case OffsetMetadataTooLarge:
 		return "Offset Metadata Too Large"
+	case NetworkException:
+		return "Network Exception"
 	case GroupLoadInProgress:
 		return "Group Load In Progress"
 	case GroupCoordinatorNotAvailable:
@@ -264,6 +295,10 @@ func (e Error) Title() string {
 		return "Unknown Leader Epoch"
 	case UnsupportedCompressionType:
 		return "Unsupported Compression Type"
+	case OffsetNotAvailable:
+		return "Offset Not Available"
+	case PreferredLeaderNotAvailable:
+		return "Preferred Leader not available"
 	}
 	return ""
 }
@@ -440,7 +475,12 @@ func isTemporary(err error) bool {
 	})
 	return ok && e.Temporary()
 }
-
+func isRetriable(err error) bool {
+	e, ok := err.(interface {
+		Retriable() bool
+	})
+	return ok && e.Retriable()
+}
 func silentEOF(err error) error {
 	if err == io.EOF {
 		err = nil

--- a/writer.go
+++ b/writer.go
@@ -724,8 +724,8 @@ func (w *writer) dial() (conn *Conn, err error) {
 	return
 }
 
-func shouldRetry(err error, retries, attempts int) bool {
-	if retries == attempts {
+func shouldRetry(err error, maxRetries, attempts int) bool {
+	if attempts >= maxRetries {
 		return false
 	}
 	//Retry Temporary Kafka errors and all network errors

--- a/writer.go
+++ b/writer.go
@@ -771,6 +771,7 @@ func (w *writer) write(conn *Conn, batch []Message, resch [](chan<- error)) (ret
 						w.topic, w.partition, err)
 				})
 				backoff(attempts, w.retryBackoffInterval, w.retryBackoffInterval)
+				conn.Close()
 				conn = nil
 				continue
 			}

--- a/writer.go
+++ b/writer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"math/rand"
+	"net"
 	"sort"
 	"sync"
 	"time"
@@ -330,7 +331,6 @@ func (w *Writer) WriteMessages(ctx context.Context, msgs ...Message) error {
 				return ctx.Err()
 			}
 		}
-
 		w.mutex.RUnlock()
 
 		if w.config.Async {
@@ -468,7 +468,6 @@ func (w *Writer) run() {
 				for _, partition := range diffp(newPartitions, oldPartitions) {
 					writers[partition] = w.open(partition)
 				}
-
 				partitions = newPartitions
 			}
 		}
@@ -481,7 +480,6 @@ func (w *Writer) run() {
 				}
 				return
 			}
-
 			if len(partitions) != 0 {
 				selectedPartition := w.config.Balancer.Balance(wm.msg, partitions...)
 				writers[selectedPartition].messages() <- wm
@@ -490,7 +488,6 @@ func (w *Writer) run() {
 				if err == nil {
 					err = fmt.Errorf("failed to find any partitions for topic %s", w.config.Topic)
 				}
-
 				wm.res <- &writerError{msg: wm.msg, err: err}
 			}
 
@@ -727,6 +724,18 @@ func (w *writer) dial() (conn *Conn, err error) {
 	return
 }
 
+func shouldRetry(err error, retries, attempts int) bool {
+	if retries == attempts {
+		return false
+	}
+	//Retry Temporary Kafka errors and all network errors
+	_, ok := err.(net.Error)
+	if isTemporary(err) || ok {
+		return true
+	}
+	return false
+}
+
 func (w *writer) write(conn *Conn, batch []Message, resch [](chan<- error)) (ret *Conn, err error) {
 	t0 := time.Now()
 	attempts := 0
@@ -737,49 +746,47 @@ func (w *writer) write(conn *Conn, batch []Message, resch [](chan<- error)) (ret
 				w.withErrorLogger(func(logger *log.Logger) {
 					logger.Printf("error dialing kafka brokers for topic %s (partition %d): %s", w.topic, w.partition, err)
 				})
+				if shouldRetry(err, w.retries, attempts) {
+					attempts = attempts + 1
+					w.stats.retries.observe(int64(attempts))
+					backoff(attempts, w.retryBackoffInterval, w.retryBackoffInterval)
+					if conn != nil {
+						conn.Close()
+					}
+					conn = nil
+					continue
+				}
 				for i, res := range resch {
 					res <- &writerError{msg: batch[i], err: err}
 				}
 				return
 			}
 		}
-
 		w.stats.writes.observe(1)
 		conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
 		if _, err = conn.WriteCompressedMessages(w.codec, batch...); err != nil {
-			w.stats.errors.observe(1)
-			//Check if we've retried the correct amount of times.
-			if w.retries == attempts {
-				break
-			}
-
-			switch err {
-			case DuplicateSequenceNumber:
-				// we've moved beyond the batch but haven't noticed it. Just return success.
-				// See https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java#L617
+			//If we get this error, just leave now as this message will never make it.
+			// https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java#L618
+			if err == DuplicateSequenceNumber {
 				err = nil
 				break
-			case TopicAuthorizationFailed, ClusterAuthorizationFailed, GroupAuthorizationFailed:
-				err = fmt.Errorf("auth error writing messages to %s (partition %d): %s", w.topic, w.partition, err)
-				break
-			default:
-				if isRetriable(err) {
-					attempts = attempts + 1
-					w.stats.retries.observe(int64(attempts))
-					err = fmt.Errorf("error writing messages to %s (partition %d): %s", w.topic, w.partition, err)
-					w.withErrorLogger(func(l *log.Logger) {
-						l.Printf("retrying batch due to potential transient error to %s (partition %d): %s",
-							w.topic, w.partition, err)
-					})
-					backoff(attempts, w.retryBackoffInterval, w.retryBackoffInterval)
-					conn.Close()
-					conn = nil
-					continue
-				}
-				// This error is nor retriable or something speical, so just get outta here.
-				break
 			}
-
+			w.stats.errors.observe(1)
+			if shouldRetry(err, w.retries, attempts) {
+				attempts = attempts + 1
+				w.stats.retries.observe(int64(attempts))
+				w.withErrorLogger(func(l *log.Logger) {
+					l.Printf("retrying batch due to potential transient error to %s (partition %d): %s", w.topic, w.partition, err)
+				})
+				backoff(attempts, w.retryBackoffInterval, w.retryBackoffInterval)
+				if conn != nil {
+					conn.Close()
+				}
+				conn = nil
+				continue
+			}
+			err = fmt.Errorf("error writing messages to %s (partition %d): %s", w.topic, w.partition, err)
+			break
 		}
 		//Successful send
 		break

--- a/writer.go
+++ b/writer.go
@@ -766,7 +766,7 @@ func (w *writer) write(conn *Conn, batch []Message, resch [](chan<- error)) (ret
 				attempts = attempts + 1
 				w.stats.retries.observe(int64(attempts))
 				err = fmt.Errorf("error writing messages to %s (partition %d): %s", w.topic, w.partition, err)
-				w.withLogger(func(l *log.Logger) {
+				w.withErrorLogger(func(l *log.Logger) {
 					l.Printf("retrying batch due to potential transient error to %s (partition %d): %s",
 						w.topic, w.partition, err)
 				})

--- a/writer_test.go
+++ b/writer_test.go
@@ -429,11 +429,11 @@ func testWriterRetryErr(t *testing.T) {
 		Message{Value: []byte("FindMe")},
 	}...)
 	if err != nil {
-		t.Error("expected  no  error, got error: ", err)
+		t.Error("expected no error, got error: ", err)
 	}
 	msgs, err := readPartition(topic, 0, offset)
 	if err != nil {
-		t.Error("expected  no  error, got error: ", err)
+		t.Error("expected no error, got error: ", err)
 	}
 	if len(msgs) != 1 {
 		t.Errorf("bad messages in partition %+v ", msgs)

--- a/writer_test.go
+++ b/writer_test.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"math"
 	"strings"
@@ -480,7 +479,6 @@ func testIntWriterRetryErr(t *testing.T) {
 	_, err = w.write(gcnn, []Message{
 		Message{Value: []byte("BadBroker")},
 	}, errc)
-	fmt.Println(err)
 	if err == nil {
 		t.Error("expected error, got nothing")
 	}


### PR DESCRIPTION
1) Adding in more tests for kafka-go 
2)   Resetup the connection to the brokers when a message batch fails to produce. If you don't you will keep retrying the using the old (and possibly broken)  connection.